### PR TITLE
Fix broken url to "Better Bloom Filter" paper

### DIFF
--- a/cl-bloom.lisp
+++ b/cl-bloom.lisp
@@ -70,7 +70,7 @@ degree of the filter according to the size of the set."
 
 ;; Cf. Kirsch and Mitzenmacher, "Less Hashing, Same
 ;; Performance: Building a Better Bloom Filter".
-;; <http://www.eecs.harvard.edu/~kirsch/pubs/bbbf/esa06.pdf>
+;; <https://www.eecs.harvard.edu/~michaelm/postscripts/tr-02-05.pdf>
 
 (declaim (inline fake-hash))
 


### PR DESCRIPTION
I noticed that this link was broken so I replaced it with a link to a copy provided by the other author